### PR TITLE
bugfix: correct model name

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -4,7 +4,7 @@ import os
 import logging
 from pickle import load
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import RandomForestClassifier
 from sklearn.pipeline import make_pipeline
 
 logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.DEBUG)
 class Classifier(object):
   def __init__(self):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
-    with open('./data/lr.pickle', 'rb') as fh:
+    with open('./data/rfc.pickle', 'rb') as fh:
       self.clf  = load(fh)
 
   def model(self):


### PR DESCRIPTION
In this PR we've:
 - replaced LogisticRegression with RandomForestClassifier in class python