### PR TITLE
chore: update base container to python v3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.11-slim-buster
+FROM docker.io/python:3.12-slim-bullseye
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk/)"
 LABEL author="uk.co.saidsef.ml-classifier=v3.0"


### PR DESCRIPTION
- chore: update base container to python v3.12