### PR TITLE
chore(deps): combine dependabot dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,12 @@ jobs:
         cd data/
         for f in *.xz; do echo `sha256sum $f` > $f.sha256sum; done
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Build and push Docker image - tag
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       env:
         DOCKER_BUILDKIT: 1
       with:
@@ -100,7 +100,7 @@ jobs:
         cache-from: type=registry,ref=docker.io/saidsef/ml-classifier:${{ env.TAG == 'main' && 'latest' || env.TAG }}
         cache-to: type=inline
     - name: Build and push Docker image - tag
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       if: ${{ contains(github.ref, 'main') }}
       env:
         DOCKER_BUILDKIT: 1

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ numpy = "==2.4.1"
 prometheus-flask-exporter = "==0.23.2"
 scikit-learn = "==1.8.0"
 werkzeug = ">=3.0.6"
-zipp = ">=3.19.1"
+zipp = ">=4.1.0"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4a3edfc09dd0c5b17c3c557a1cfd992632d204ae4ccb60557a7dce2b488dc0ed"
+            "sha256": "f3711f9a5f1372f7fd63df7a7cf3c1d630234a845c8e2faa444325d5a08c345d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -402,12 +402,12 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc",
-                "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"
+                "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f",
+                "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==3.23.1"
+            "markers": "python_version >= '3.10'",
+            "version": "==4.1.0"
         }
     },
     "develop": {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -i https://pypi.org/simple
 flask==3.1.3
-flask_wtf==1.2.2
+flask_wtf==1.3.0
 numpy==1.26.4
 prometheus-flask-exporter==0.23.2
 scikit-learn==1.8.0
@@ -9,4 +9,4 @@ scikit-learn==1.8.0
 # pandas==2.1.1
 # seaborn==0.13.0
 werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
-zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp>=4.1.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary

Combines 4 open dependabot PRs into a single update (excludes numpy).

| Dependency | From | To | Type | Closes |
|---|---|---|---|---|
| `zipp` | 3.23.1 | 4.1.0 | Python (semver-major) | #261 |
| `flask-wtf` | 1.2.2 | 1.3.0 | Python (semver-minor) | #260 |
| `docker/login-action` | v3 | v4 | GitHub Actions (semver-major) | #253 |
| `docker/build-push-action` | v6 | v7 | GitHub Actions (semver-major) | #252 |

## Files changed

- `Pipfile` - zipp version constraint bumped to `>=4.1.0`
- `Pipfile.lock` - zipp hashes and version updated to `==4.1.0`
- `requirements.txt` - flask-wtf bumped to `==1.3.0`, zipp bumped to `>=4.1.0`
- `.github/workflows/ci.yml` - docker/login-action and docker/build-push-action major version bumps

## Test plan

- [x] CI passes (CodeQL, build, k8s-test)
- [x] Docker image builds and pushes successfully with `docker/build-push-action@v7`
- [x] Docker login works with `docker/login-action@v4`
- [x] Python dependencies install cleanly with updated zipp and flask-wtf versions