### PR TITLE
fix(security): upgrade base image to python:3.12-slim-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.12-slim-bookworm
+FROM docker.io/python:3.12-slim-trixie
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk/)"
 LABEL author="uk.co.saidsef.ml-classifier=v3.0"


### PR DESCRIPTION
## Summary

- Replaces `python:3.12-slim-bookworm` (Debian 12) with `python:3.12-slim-trixie` (Debian 13) to reduce CVE exposure, continuing the pattern from #263
- All Python dependencies install cleanly against the new base
- No application code changes

## Testing

Tested locally before merging:

- [x] `docker build` completes successfully
- [x] Container starts and serves on `PORT=7070`
- [x] `GET /` returns route listing
- [x] `GET /metrics` returns Prometheus metrics
- [x] `POST /api/v1/news` behaviour identical to `slim-bookworm` (pre-existing scikit-learn 1.6.1 -> 1.8.0 pickle compat warning is unrelated to this change)