### PR TITLE
chore: upgrade Python base image to 3.14 and deployment tag to v2026.05

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.12-slim-trixie
+FROM docker.io/python:3.14-slim-trixie
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk/)"
 LABEL author="uk.co.saidsef.ml-classifier=v3.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ My goal is to show you how to create a predictive model(s) that will classificat
 
 ## Prerequisite
 
-- Python >= v3.11
+- Python >= v3.12
 - Jupyter Notebook
 - Some knowledge of Machine Learning
 

--- a/deployment/base/deployment.yml
+++ b/deployment/base/deployment.yml
@@ -25,7 +25,7 @@ spec:
       securityContext: {}
       containers:
       - name: classifier
-        image: docker.io/saidsef/ml-classifier:v2024.09
+        image: docker.io/saidsef/ml-classifier:v2026.05
         imagePullPolicy: Always
         ports:
         - containerPort: 7070

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: docker.io/saidsef/ml-classifier
 - newName: docker.io/saidsef/ml-classifier
-- newTag: v2024.09
+- newTag: v2026.05


### PR DESCRIPTION
## Summary

- Bumps the Docker base image from `python:3.12-slim-trixie` to `python:3.14-slim-trixie` to stay on the latest stable Python release
- Updates the Kubernetes deployment image tag from `v2024.09` to `v2026.05` in both `deployment/base/deployment.yml` and `deployment/kustomization.yml`
- Updates the README prerequisite to reflect Python >= v3.12

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Base image: `python:3.12-slim-trixie` -> `python:3.14-slim-trixie` |
| `deployment/base/deployment.yml` | Image tag: `v2024.09` -> `v2026.05` |
| `deployment/kustomization.yml` | newTag: `v2024.09` -> `v2026.05` |
| `README.md` | Prerequisite: Python `>= v3.11` -> `>= v3.12` |

## Test plan

- [x] Verify Docker image builds successfully with Python 3.14 base
- [ ] Confirm deployment rolls out cleanly with the new image tag
- [ ] Run existing test suite to check for Python 3.14 compatibility regressions